### PR TITLE
minor refactor & allow compiling on start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*.gem
 /.ruby-version
+/Gemfile.lock
 /.idea/
 /pkg/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-*.gem
+/*.gem
+/.ruby-version
+/.idea/
+/pkg/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require "bundler/gem_tasks"

--- a/guard-concat.gemspec
+++ b/guard-concat.gemspec
@@ -1,8 +1,4 @@
 # encoding: utf-8
-begin
-  require File.expand_path("../lib/guard/concat", __FILE__)
-rescue LoadError
-end
 
 Gem::Specification.new do |s|
   s.name         = "guard-concat"
@@ -10,7 +6,7 @@ Gem::Specification.new do |s|
   s.email        = "makevoid@gmail.com"
   s.summary      = "Guard gem for concatenating (js/css) files"
   s.homepage     = "http://github.com/makevoid/guard-concat"
-  s.version      = Guard::Concat::VERSION rescue '0.0'
+  s.version      = '0.0.5'
 
   s.description  = <<-DESC
     Guard::Concat automatically concatenates files in one when watched files are modified.

--- a/guard-concat.gemspec
+++ b/guard-concat.gemspec
@@ -1,5 +1,8 @@
 # encoding: utf-8
-require File.expand_path("../lib/guard/concat", __FILE__)
+begin
+  require File.expand_path("../lib/guard/concat", __FILE__)
+rescue LoadError
+end
 
 Gem::Specification.new do |s|
   s.name         = "guard-concat"
@@ -7,7 +10,7 @@ Gem::Specification.new do |s|
   s.email        = "makevoid@gmail.com"
   s.summary      = "Guard gem for concatenating (js/css) files"
   s.homepage     = "http://github.com/makevoid/guard-concat"
-  s.version      = Guard::Concat::VERSION
+  s.version      = Guard::Concat::VERSION rescue '0.0'
 
   s.description  = <<-DESC
     Guard::Concat automatically concatenates files in one when watched files are modified.

--- a/lib/guard/concat.rb
+++ b/lib/guard/concat.rb
@@ -8,11 +8,18 @@ module Guard
 
     def initialize(watchers=[], opts={})
       @opts = opts
-      concat if all_on_start?
       watchers << ::Guard::Watcher.new(matcher_regex)
       super(watchers, opts)
     end
 
+    def start
+      run_all if all_on_start?
+    end
+    
+    def run_all
+      concat
+    end
+    
     def run_on_changes(paths)
       concat
     end

--- a/lib/guard/concat.rb
+++ b/lib/guard/concat.rb
@@ -4,8 +4,6 @@ require 'guard/watcher'
 
 module Guard
   class Concat < Guard
-    VERSION = '0.0.4'
-
     def initialize(watchers=[], opts={})
       @opts = opts
       watchers << ::Guard::Watcher.new(matcher_regex)
@@ -15,11 +13,11 @@ module Guard
     def start
       run_all if all_on_start?
     end
-    
+
     def run_all
       concat
     end
-    
+
     def run_on_changes(paths)
       concat
     end


### PR DESCRIPTION
Hi!
I wanted to add compiling on start of guard. So first I've added bundler support to install dependencies and extracted some magic variables to methods.
Then i've added `:all_on_start` option (same as guard-coffee) to concat all files on start of guard.

Cheers!