### PR TITLE
Adding start method into constructor to fix all_on_start been ignored.

### DIFF
--- a/guard-concat.gemspec
+++ b/guard-concat.gemspec
@@ -1,4 +1,4 @@
-require_relative "lib/guard/concat/version"
+require File.expand_path(File.join(File.dirname(__FILE__), 'lib/guard/concat/version'))
 
 Gem::Specification.new do |s|
   s.name         = "guard-concat"

--- a/lib/guard/concat.rb
+++ b/lib/guard/concat.rb
@@ -10,6 +10,7 @@ module Guard
       opts[:watchers] = [] unless opts[:watchers]
       opts[:watchers] << ::Guard::Watcher.new(matcher_regex)
       super(opts)
+      start
     end
 
     def start


### PR DESCRIPTION
This pull request fixes two issues.
1. Adding start method into constructor to fix all_on_start been ignored. So the contact can be run as below format

``` ruby
    watch(watcher_reg_wrapper(THEME_MAIN_PATH,'py|xml')) do
      __('Merging JavaScripts ....', 'info')
      guard('concat', opts = {all_on_start: true, type: "js", files:compile(), input_dir: JS_TMP_FOLDER, output: JS_PATH + "/dev/main", verbose:true})
    end
```
1. Fixing error when adding into gem with github.

> There was a LoadError while loading guard-concat.gemspec: 
> cannot infer basepath from
>  ~/home/x/.bundler/ruby/1.9.1/guard-concat-2ff7948b294c/guard-concat.gemspec:1:in >`require_relative'
> 
> Does it try to require a relative path? That's been removed in Ruby 1.9.
